### PR TITLE
update for c++11+ visual studio build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,8 @@ redis3m.pc
 patterns_test
 docs
 cluster_pool_test
+Redis3M-VisualStudio/ipch/
+Redis3M-VisualStudio/Release/
+Redis3M-VisualStudio/Debug/
+Redis3M-VisualStudio/Redis3M-VisualStudio/Debug/
+*.sdf

--- a/Redis3M-VisualStudio/Examples/Examples.vcxproj
+++ b/Redis3M-VisualStudio/Examples/Examples.vcxproj
@@ -1,0 +1,99 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{3D8ACE48-611C-4564-A22F-DB3C3B991EC0}</ProjectGuid>
+    <Keyword>MakeFileProj</Keyword>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Makefile</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Makefile</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Makefile</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Makefile</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <NMakeBuildCommandLine>nmake CONFIGURATION=$(Configuration) PLATFORM=$(Platform)</NMakeBuildCommandLine>
+    <NMakeOutput>simple.exe</NMakeOutput>
+    <NMakeCleanCommandLine>nmake CONFIGURATION=$(Configuration) PLATFORM=$(PLATFORM) clean</NMakeCleanCommandLine>
+    <NMakeReBuildCommandLine>nmake CONFIGURATION=$(Configuration) PLATFORM=$(PLATFORM) rebuild</NMakeReBuildCommandLine>
+    <NMakePreprocessorDefinitions>NO_BOOST;WIN32;_DEBUG;$(NMakePreprocessorDefinitions)</NMakePreprocessorDefinitions>
+    <NMakeIncludeSearchPath>$(SolutionDir)..\include;$(NMakeIncludeSearchPath)</NMakeIncludeSearchPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <NMakeBuildCommandLine>nmake CONFIGURATION=$(Configuration) PLATFORM=$(Platform)</NMakeBuildCommandLine>
+    <NMakeOutput>simple.exe</NMakeOutput>
+    <NMakeCleanCommandLine>nmake CONFIGURATION=$(Configuration) PLATFORM=$(PLATFORM) clean</NMakeCleanCommandLine>
+    <NMakeReBuildCommandLine>nmake CONFIGURATION=$(Configuration) PLATFORM=$(PLATFORM) rebuild</NMakeReBuildCommandLine>
+    <NMakePreprocessorDefinitions>NO_BOOST;WIN32;_DEBUG;$(NMakePreprocessorDefinitions)</NMakePreprocessorDefinitions>
+    <NMakeIncludeSearchPath>$(SolutionDir)..\include;$(NMakeIncludeSearchPath)</NMakeIncludeSearchPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <NMakeBuildCommandLine>nmake CONFIGURATION=$(Configuration) PLATFORM=$(Platform)</NMakeBuildCommandLine>
+    <NMakeOutput>simple.exe</NMakeOutput>
+    <NMakeCleanCommandLine>nmake CONFIGURATION=$(Configuration) PLATFORM=$(PLATFORM) clean</NMakeCleanCommandLine>
+    <NMakeReBuildCommandLine>nmake CONFIGURATION=$(Configuration) PLATFORM=$(PLATFORM) rebuild</NMakeReBuildCommandLine>
+    <NMakePreprocessorDefinitions>NO_BOOST;WIN32;NDEBUG;$(NMakePreprocessorDefinitions)</NMakePreprocessorDefinitions>
+    <NMakeIncludeSearchPath>$(SolutionDir)..\include;$(NMakeIncludeSearchPath)</NMakeIncludeSearchPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <NMakeBuildCommandLine>nmake CONFIGURATION=$(Configuration) PLATFORM=$(Platform)</NMakeBuildCommandLine>
+    <NMakeOutput>simple.exe</NMakeOutput>
+    <NMakeCleanCommandLine>nmake CONFIGURATION=$(Configuration) PLATFORM=$(PLATFORM) clean</NMakeCleanCommandLine>
+    <NMakeReBuildCommandLine>nmake CONFIGURATION=$(Configuration) PLATFORM=$(PLATFORM) rebuild</NMakeReBuildCommandLine>
+    <NMakePreprocessorDefinitions>NO_BOOST;WIN32;NDEBUG;$(NMakePreprocessorDefinitions)</NMakePreprocessorDefinitions>
+    <NMakeIncludeSearchPath>$(SolutionDir)..\include;$(NMakeIncludeSearchPath)</NMakeIncludeSearchPath>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Redis3M-VisualStudio/Examples/Examples.vcxproj.filters
+++ b/Redis3M-VisualStudio/Examples/Examples.vcxproj.filters
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+</Project>

--- a/Redis3M-VisualStudio/Redis3M-VisualStudio.sln
+++ b/Redis3M-VisualStudio/Redis3M-VisualStudio.sln
@@ -1,0 +1,41 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Express 2013 for Windows Desktop
+VisualStudioVersion = 12.0.30723.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Redis3M-VisualStudio", "Redis3M-VisualStudio\Redis3M-VisualStudio.vcxproj", "{EE13AABD-8E82-4B84-B88C-8FA544D8849B}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Examples", "Examples\Examples.vcxproj", "{3D8ACE48-611C-4564-A22F-DB3C3B991EC0}"
+	ProjectSection(ProjectDependencies) = postProject
+		{EE13AABD-8E82-4B84-B88C-8FA544D8849B} = {EE13AABD-8E82-4B84-B88C-8FA544D8849B}
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Win32 = Debug|Win32
+		Debug|x64 = Debug|x64
+		Release|Win32 = Release|Win32
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{EE13AABD-8E82-4B84-B88C-8FA544D8849B}.Debug|Win32.ActiveCfg = Debug|Win32
+		{EE13AABD-8E82-4B84-B88C-8FA544D8849B}.Debug|Win32.Build.0 = Debug|Win32
+		{EE13AABD-8E82-4B84-B88C-8FA544D8849B}.Debug|x64.ActiveCfg = Debug|x64
+		{EE13AABD-8E82-4B84-B88C-8FA544D8849B}.Debug|x64.Build.0 = Debug|x64
+		{EE13AABD-8E82-4B84-B88C-8FA544D8849B}.Release|Win32.ActiveCfg = Release|Win32
+		{EE13AABD-8E82-4B84-B88C-8FA544D8849B}.Release|Win32.Build.0 = Release|Win32
+		{EE13AABD-8E82-4B84-B88C-8FA544D8849B}.Release|x64.ActiveCfg = Release|x64
+		{EE13AABD-8E82-4B84-B88C-8FA544D8849B}.Release|x64.Build.0 = Release|x64
+		{3D8ACE48-611C-4564-A22F-DB3C3B991EC0}.Debug|Win32.ActiveCfg = Debug|Win32
+		{3D8ACE48-611C-4564-A22F-DB3C3B991EC0}.Debug|Win32.Build.0 = Debug|Win32
+		{3D8ACE48-611C-4564-A22F-DB3C3B991EC0}.Debug|x64.ActiveCfg = Debug|x64
+		{3D8ACE48-611C-4564-A22F-DB3C3B991EC0}.Debug|x64.Build.0 = Debug|x64
+		{3D8ACE48-611C-4564-A22F-DB3C3B991EC0}.Release|Win32.ActiveCfg = Release|Win32
+		{3D8ACE48-611C-4564-A22F-DB3C3B991EC0}.Release|Win32.Build.0 = Release|Win32
+		{3D8ACE48-611C-4564-A22F-DB3C3B991EC0}.Release|x64.ActiveCfg = Release|x64
+		{3D8ACE48-611C-4564-A22F-DB3C3B991EC0}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/Redis3M-VisualStudio/Redis3M-VisualStudio/Redis3M-VisualStudio.vcxproj
+++ b/Redis3M-VisualStudio/Redis3M-VisualStudio/Redis3M-VisualStudio.vcxproj
@@ -1,0 +1,188 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{EE13AABD-8E82-4B84-B88C-8FA544D8849B}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>Redis3MVisualStudio</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <OutDir>$(SolutionDir)$(Configuration)\$(Platform)\</OutDir>
+    <IntDir>$(SolutionDir)$(Configuration)\$(Platform)\Intermediate\</IntDir>
+    <TargetName>redis3m</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <OutDir>$(SolutionDir)$(Configuration)\$(Platform)\</OutDir>
+    <IntDir>$(SolutionDir)$(Configuration)\$(Platform)\Intermediate\</IntDir>
+    <TargetName>redis3m</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <OutDir>$(SolutionDir)$(Configuration)\$(Platform)\</OutDir>
+    <IntDir>$(SolutionDir)$(Configuration)\$(Platform)\Intermediate\</IntDir>
+    <TargetName>redis3m</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <OutDir>$(SolutionDir)$(Configuration)\$(Platform)\</OutDir>
+    <IntDir>$(SolutionDir)$(Configuration)\$(Platform)\Intermediate\</IntDir>
+    <TargetName>redis3m</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>NO_BOOST=1;WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>$(Projectdir);$(SolutionDir)..\include;E:\github\redis\deps</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>NO_BOOST=1;WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <AdditionalIncludeDirectories>$(Projectdir);$(SolutionDir)..\include;E:\github\redis\deps</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>NO_BOOST=1;WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>$(Projectdir);$(SolutionDir)..\include;E:\github\redis\deps</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>NO_BOOST=1;WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <AdditionalIncludeDirectories>$(Projectdir);$(SolutionDir)..\include;E:\github\redis\deps</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\include\redis3m\cluster_pool.h" />
+    <ClInclude Include="..\..\include\redis3m\command.h" />
+    <ClInclude Include="..\..\include\redis3m\connection.h" />
+    <ClInclude Include="..\..\include\redis3m\connection_pool.h" />
+    <ClInclude Include="..\..\include\redis3m\NoCopy.h" />
+    <ClInclude Include="..\..\include\redis3m\redis3m.hpp" />
+    <ClInclude Include="..\..\include\redis3m\reply.h" />
+    <ClInclude Include="..\..\include\redis3m\simple_pool.h" />
+    <ClInclude Include="stdafx.h" />
+    <ClInclude Include="targetver.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\cluster_pool.cpp" />
+    <ClCompile Include="..\..\src\connection.cpp" />
+    <ClCompile Include="..\..\src\connection_pool.cpp" />
+    <ClCompile Include="..\..\src\patterns\median_filter.cpp" />
+    <ClCompile Include="..\..\src\patterns\script_exec.cpp" />
+    <ClCompile Include="..\..\src\reply.cpp" />
+    <ClCompile Include="..\..\src\simple_pool.cpp" />
+    <ClCompile Include="..\..\src\utils\crc16.cpp" />
+    <ClCompile Include="..\..\src\utils\file.cpp" />
+    <ClCompile Include="..\..\src\utils\logging.cpp" />
+    <ClCompile Include="..\..\src\utils\resolv.cpp" />
+    <ClCompile Include="..\..\src\utils\sha1.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Redis3M-VisualStudio/Redis3M-VisualStudio/Redis3M-VisualStudio.vcxproj.filters
+++ b/Redis3M-VisualStudio/Redis3M-VisualStudio/Redis3M-VisualStudio.vcxproj.filters
@@ -1,0 +1,96 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Source Files\src">
+      <UniqueIdentifier>{e8c51318-9227-4732-99db-4674d0ac542a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\patterns">
+      <UniqueIdentifier>{b485c4b3-0f16-4eaa-a2af-0d22b84b3008}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\utils">
+      <UniqueIdentifier>{f45916e8-1bd1-4d0f-9e70-fc3d1ea33cf6}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="stdafx.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="targetver.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\redis3m\cluster_pool.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\redis3m\command.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\redis3m\connection.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\redis3m\connection_pool.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\redis3m\redis3m.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\redis3m\reply.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\redis3m\simple_pool.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\redis3m\NoCopy.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\cluster_pool.cpp">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\connection.cpp">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\connection_pool.cpp">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\reply.cpp">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\simple_pool.cpp">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\patterns\median_filter.cpp">
+      <Filter>Source Files\src\patterns</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\patterns\script_exec.cpp">
+      <Filter>Source Files\src\patterns</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\utils\crc16.cpp">
+      <Filter>Source Files\src\utils</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\utils\file.cpp">
+      <Filter>Source Files\src\utils</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\utils\logging.cpp">
+      <Filter>Source Files\src\utils</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\utils\resolv.cpp">
+      <Filter>Source Files\src\utils</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\utils\sha1.cpp">
+      <Filter>Source Files\src\utils</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/Redis3M-VisualStudio/Redis3M-VisualStudio/stdafx.h
+++ b/Redis3M-VisualStudio/Redis3M-VisualStudio/stdafx.h
@@ -1,0 +1,14 @@
+// stdafx.h : include file for standard system include files,
+// or project specific include files that are used frequently, but
+// are changed infrequently
+//
+
+#pragma once
+
+#include "targetver.h"
+
+#define WIN32_LEAN_AND_MEAN             // Exclude rarely-used stuff from Windows headers
+#define NO_GDI
+
+
+// TODO: reference additional headers your program requires here

--- a/Redis3M-VisualStudio/Redis3M-VisualStudio/targetver.h
+++ b/Redis3M-VisualStudio/Redis3M-VisualStudio/targetver.h
@@ -1,0 +1,8 @@
+#pragma once
+
+// Including SDKDDKVer.h defines the highest available Windows platform.
+
+// If you wish to build your application for a previous Windows platform, include WinSDKVer.h and
+// set the _WIN32_WINNT macro to the platform you wish to support before including SDKDDKVer.h.
+
+#include <SDKDDKVer.h>

--- a/include/redis3m/NoCopy.h
+++ b/include/redis3m/NoCopy.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#define NOCOPY(classname)					private: \
+												explicit classname(const classname&); \
+												classname& operator=(const classname&);
+#ifdef NO_BOOST
+class NoCopy
+{
+	NOCOPY(NoCopy);
+public:
+
+};
+#define NOCOPY_BASE  
+#else
+#include <boost/noncopyable.hpp>
+#define NOCOPY_BASE : boost::noncopyable
+#endif

--- a/include/redis3m/cluster_pool.h
+++ b/include/redis3m/cluster_pool.h
@@ -1,12 +1,11 @@
 #pragma once
-
-#include <boost/noncopyable.hpp>
 #include <memory>
 #include <string>
 #include <vector>
 #include <redis3m/reply.h>
 #include <redis3m/connection.h>
 #include <redis3m/utils/pool.h>
+#include <redis3m/NoCopy.h>
 #include <map>
 #include <mutex>
 #include <set>
@@ -15,8 +14,10 @@
 
 namespace redis3m
 {
-class cluster_pool: boost::noncopyable
+
+class cluster_pool NOCOPY_BASE
 {
+
 public:
     REDIS3M_EXCEPTION(cannot_regenerate_slots_map)
     typedef std::shared_ptr<cluster_pool> ptr_t;

--- a/include/redis3m/command.h
+++ b/include/redis3m/command.h
@@ -5,7 +5,9 @@
 
 #include <string>
 #include <vector>
+#ifndef NO_BOOST
 #include <boost/lexical_cast.hpp>
+#endif
 
 namespace redis3m
 {
@@ -19,7 +21,7 @@ public:
     {
         _args.push_back(arg);
     }
-
+#ifndef NO_BOOST
     template<typename Type>
     inline command& operator<<(const Type arg)
     {
@@ -33,6 +35,21 @@ public:
         _args.push_back(boost::lexical_cast<std::string>(arg));
         return *this;
     }
+#else
+	template<typename Type>
+	inline command& operator<<(const Type arg)
+	{
+		_args.push_back(std::to_string(arg));
+		return *this;
+	}
+
+	template<typename Type>
+	inline command& operator()(const Type arg)
+	{
+		_args.push_back(std::to_string(arg));
+		return *this;
+	}
+#endif	
 
     inline operator const std::vector<std::string>& () {
         return _args;
@@ -41,7 +58,6 @@ public:
 private:
     std::vector<std::string> _args;
 };
-
 template<>
 inline command& command::operator<<(const char* arg)
 {
@@ -57,16 +73,16 @@ inline command& command::operator()(const char* arg)
 }
 
 template<>
-inline command& command::operator<<(const std::string& arg)
+inline command& command::operator<<(std::string arg)
 {
-    _args.push_back(arg);
+    _args.push_back(std::move(arg));
     return *this;
 }
 
 template<>
-inline command& command::operator()(const std::string& arg)
+inline command& command::operator()(std::string arg)
 {
-    _args.push_back(arg);
+	_args.push_back(std::move(arg));
     return *this;
 }
 }

--- a/include/redis3m/connection.h
+++ b/include/redis3m/connection.h
@@ -6,23 +6,24 @@
 #include <string>
 #include <redis3m/utils/exception.h>
 #include <redis3m/reply.h>
+#include <redis3m/NoCopy.h>
 #include <vector>
 #include <memory>
-#include <boost/noncopyable.hpp>
 
 struct redisContext;
 
 namespace redis3m {
-REDIS3M_EXCEPTION(connection_error)
-REDIS3M_EXCEPTION_2(unable_to_connect, connection_error)
-REDIS3M_EXCEPTION_2(transport_failure, connection_error)
-REDIS3M_EXCEPTION_2(slave_read_only, connection_error)
+	REDIS3M_EXCEPTION(connection_error)
+		REDIS3M_EXCEPTION_2(unable_to_connect, connection_error)
+		REDIS3M_EXCEPTION_2(transport_failure, connection_error)
+		REDIS3M_EXCEPTION_2(slave_read_only, connection_error)
 
-/**
-* @brief The connection class, represent a connection to a Redis server
-*/
-class connection: boost::noncopyable
-{
+		/**
+		* @brief The connection class, represent a connection to a Redis server
+		*/
+
+	class connection NOCOPY_BASE
+	{
 public:
     typedef std::shared_ptr<connection> ptr_t;
 

--- a/include/redis3m/connection_pool.h
+++ b/include/redis3m/connection_pool.h
@@ -8,8 +8,8 @@
 #include <redis3m/connection.h>
 #include <memory>
 #include <mutex>
-#include <boost/noncopyable.hpp>
 #include <redis3m/utils/exception.h>
+#include <redis3m/NoCopy.h>
 
 namespace redis3m {
     REDIS3M_EXCEPTION(cannot_find_sentinel)
@@ -22,7 +22,8 @@ namespace redis3m {
      * @brief Manages a connection pool, using a Redis Sentinel
      * to get instances ip, managing also failover
      */
-    class connection_pool: boost::noncopyable
+
+    class connection_pool NOCOPY_BASE
     {
     public:
         typedef std::shared_ptr<connection_pool> ptr_t;
@@ -117,3 +118,4 @@ namespace redis3m {
                                 connection::role_t conn_type,
                                 unsigned int retries);
 }
+

--- a/include/redis3m/patterns/scheduler.h
+++ b/include/redis3m/patterns/scheduler.h
@@ -6,8 +6,10 @@
 #include <string>
 #include <redis3m/patterns/script_exec.h>
 #include <redis3m/connection.h>
+#ifndef NO_BOOST
 #include <boost/date_time/posix_time/ptime.hpp>
 #include <boost/date_time/posix_time/posix_time_duration.hpp>
+#endif
 
 namespace redis3m
 {

--- a/include/redis3m/reply.h
+++ b/include/redis3m/reply.h
@@ -20,14 +20,14 @@ public:
     /**
      * @brief Define reply type
      */
-    enum type_t
+    enum class type_t
     {
-        STRING = 1,
-        ARRAY = 2,
-        INTEGER = 3,
-        NIL = 4,
-        STATUS = 5,
-        ERROR = 6
+        TYPE_STRING = 1,
+        TYPE_ARRAY = 2,
+        TYPE_INTEGER = 3,
+        TYPE_NIL = 4,
+        TYPE_STATUS = 5,
+        TYPE_ERROR = 6
     };
 
     /**
@@ -57,7 +57,7 @@ public:
 
     inline bool operator==(const std::string& rvalue) const
     {
-        if (_type == STRING || _type == ERROR || _type == STATUS)
+		if (_type == type_t::TYPE_STRING || _type == type_t::TYPE_ERROR || _type == type_t::TYPE_STATUS)
         {
             return _str == rvalue;
         }
@@ -69,7 +69,7 @@ public:
 
     inline bool operator==(const long long rvalue) const
     {
-        if (_type == INTEGER)
+		if (_type == type_t::TYPE_INTEGER)
         {
             return _integer == rvalue;
         }

--- a/include/redis3m/simple_pool.h
+++ b/include/redis3m/simple_pool.h
@@ -2,8 +2,7 @@
 // Licensed under Apache 2.0, see LICENSE for details
 
 #pragma once
-
-#include <boost/noncopyable.hpp>
+#include <redis3m/NoCopy.h>
 #include <redis3m/connection.h>
 #include <set>
 #include <memory>
@@ -15,7 +14,8 @@ namespace redis3m
 /**
  * @brief Manages a pool of connections to a single Redis server
  */
-class simple_pool: boost::noncopyable
+
+class simple_pool NOCOPY_BASE
 {
 public:
     typedef std::shared_ptr<simple_pool> ptr_t;

--- a/include/redis3m/utils/pool.h
+++ b/include/redis3m/utils/pool.h
@@ -3,7 +3,10 @@
 #include <mutex>
 #include <functional>
 #include <forward_list>
+#ifndef NO_BOOST
 #include <boost/noncopyable.hpp>
+#endif
+#include <redis3m/NoCopy.h>
 
 namespace redis3m
 {
@@ -11,7 +14,8 @@ namespace utils
 {
 
 template<typename T>
-class pool: boost::noncopyable
+
+class pool NOCOPY_BASE
 {
     std::function<T(void)> builder;
     std::mutex access_mutex;

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -3,7 +3,9 @@
 
 #include <redis3m/connection.h>
 #include <hiredis/hiredis.h>
+#ifndef NO_BOOST
 #include <boost/algorithm/string/predicate.hpp>
+#endif
 
 using namespace redis3m;
 
@@ -52,8 +54,12 @@ reply connection::get_reply()
     reply ret(r);
     freeReplyObject(r);
 
-    if (ret.type() == reply::ERROR &&
+    if (ret.type() == reply::type_t::TYPE_ERROR &&
+#ifndef NO_BOOST
         boost::algorithm::starts_with(ret.str(), "READONLY"))
+#else
+		(ret.str().find("READONLY") == 0) )
+#endif
     {
         throw slave_read_only();
     }
@@ -63,7 +69,7 @@ reply connection::get_reply()
 std::vector<reply> connection::get_replies(unsigned int count)
 {
     std::vector<reply> ret;
-    for (int i=0; i < count; ++i)
+    for (unsigned int i=0; i < count; ++i)
     {
         ret.push_back(get_reply());
     }

--- a/src/patterns/median_filter.cpp
+++ b/src/patterns/median_filter.cpp
@@ -2,7 +2,9 @@
 // Licensed under Apache 2.0, see LICENSE for details
 #include <redis3m/patterns/median_filter.h>
 #include <redis3m/utils/file.h>
+#ifndef NO_BOOST
 #include <boost/lexical_cast.hpp>
+#endif
 #include <redis3m/command.h>
 
 using namespace redis3m;
@@ -30,11 +32,17 @@ double median_filter::median(connection::ptr_t connection, const std::string &ta
 {
     reply r = connection->run(command("SORT") << list_key(tag));
     const std::vector<reply>& values = r.elements();
-    int size = values.size();
+    int size = (int)values.size();
 
     if (size % 2 != 0)
     {
-        return boost::lexical_cast<double>(values.at((size-1)/2).str());
+		return 
+#ifndef NO_BOOST
+        boost::lexical_cast<double>
+#else
+		std::stod
+#endif
+		(values.at((size - 1) / 2).str());
     }
     else
     {
@@ -44,8 +52,13 @@ double median_filter::median(connection::ptr_t connection, const std::string &ta
         }
         else
         {
+#ifndef NO_BOOST
             return ( boost::lexical_cast<double>(values.at(size/2-1).str()) +
                 boost::lexical_cast<double>(values.at(size/2).str()) ) / 2;
+#else
+			return (std::stod(values.at(size / 2 - 1).str()) +
+				std::stod(values.at(size / 2).str())) / 2;
+#endif
         }
     }
 }

--- a/src/patterns/script_exec.cpp
+++ b/src/patterns/script_exec.cpp
@@ -3,9 +3,14 @@
 
 #include <redis3m/patterns/script_exec.h>
 #include <redis3m/utils/sha1.h>
+#ifndef NO_BOOST
 #include <boost/lexical_cast.hpp>
+#endif
 #include <redis3m/utils/file.h>
+#ifndef NO_BOOST
 #include <boost/algorithm/string/predicate.hpp>
+#endif
+
 
 using namespace redis3m;
 
@@ -18,11 +23,11 @@ _is_path(is_path)
     if (_is_path)
     {
         std::string script_content = utils::read_content_of_file(script);
-        sha1::calc(script_content.c_str(),script_content.size(),hash);
+        sha1::calc(script_content.c_str(),(int)script_content.size(),hash);
     }
     else
     {
-        sha1::calc(script.c_str(),script.size(),hash);
+        sha1::calc(script.c_str(),(int)script.size(),hash);
     }
     sha1::toHexString(hash, hexstring);
     _sha1.assign(hexstring);
@@ -37,12 +42,21 @@ reply patterns::script_exec::exec(connection::ptr_t connection,
 
     exec_command.push_back("EVALSHA");
     exec_command.push_back(_sha1);
+#ifndef NO_BOOST
     exec_command.push_back(boost::lexical_cast<std::string>(keys.size()));
+#else
+	exec_command.push_back(std::to_string(keys.size()));
+#endif
     exec_command.insert(exec_command.end(), keys.begin(), keys.end());
     exec_command.insert(exec_command.end(), args.begin(), args.end());
     reply r = connection->run(exec_command);
-    if (r.type() == reply::ERROR &&
-        boost::starts_with(r.str(), "NOSCRIPT") )
+    if (r.type() == reply::type_t::TYPE_ERROR &&
+#ifndef NO_BOOST
+        boost::starts_with(r.str(), "NOSCRIPT") 
+#else
+		r.str().find("NOSCRIPT") == 0 
+#endif
+		)
     {
         exec_command[0] = "EVAL";
         if (_is_path)

--- a/src/reply.cpp
+++ b/src/reply.cpp
@@ -1,26 +1,26 @@
 // Copyright (c) 2014 Luca Marturana. All rights reserved.
 // Licensed under Apache 2.0, see LICENSE for details
 
-#include <redis3m/reply.h>
 #include <hiredis/hiredis.h>
+#include <redis3m/reply.h>
 
 using namespace redis3m;
 
 reply::reply(redisReply *c_reply):
-_type(ERROR),
+_type(type_t::TYPE_ERROR),
 _integer(0)
 {
     _type = static_cast<type_t>(c_reply->type);
     switch (_type) {
-        case ERROR:
-        case STRING:
-        case STATUS:
+	case type_t::TYPE_ERROR:
+	case type_t::TYPE_STRING:
+	case type_t::TYPE_STATUS:
             _str = std::string(c_reply->str, c_reply->len);
             break;
-        case INTEGER:
+	case type_t::TYPE_INTEGER:
             _integer = c_reply->integer;
             break;
-        case ARRAY:
+	case type_t::TYPE_ARRAY:
             for (size_t i=0; i < c_reply->elements; ++i) {
                 _elements.push_back(reply(c_reply->element[i]));
             }

--- a/src/simple_pool.cpp
+++ b/src/simple_pool.cpp
@@ -62,7 +62,7 @@ void simple_pool::run_with_connection(std::function<void(connection::ptr_t)> f,
             f(c);
             put(c);
             return;
-        } catch (const connection_error& ex)
+        } catch (const connection_error& )
         {
             --retries;
         }

--- a/src/utils/resolv.cpp
+++ b/src/utils/resolv.cpp
@@ -2,10 +2,15 @@
 // Licensed under Apache 2.0, see LICENSE for details
 
 #include <redis3m/utils/resolv.h>
+#ifndef _MSC_VER
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netdb.h>
 #include <arpa/inet.h>
+#else
+#include <WinSock2.h>
+#include <WS2tcpip.h>
+#endif
 #include <string.h>
 
 using namespace redis3m;


### PR DESCRIPTION
hi,
I added Visual studio 2013 solution and also updated the code to c++11 where I could.

I have defined a NO_BOOST preprocessor macro (most of the functionality except boost::format seems to be in c++11 and for various reasons I can't use boost in my code).  This does litter the code a bit, so feel free to make suggestions on how to resolve those.  

My preference would be to remove boost completely where it can be removed. The one big area I didn't touch is scheduler.cpp/.h  where I believe std::chrono could be used instead of boost..

thanks.
