### PR TITLE
making exceptions more verbose

### DIFF
--- a/include/redis3m/utils/exception.h
+++ b/include/redis3m/utils/exception.h
@@ -3,28 +3,26 @@
 
 #pragma once
 
-#include <exception>
+#include <stdexcept>
 #include <string>
+#include <utility>
 
 namespace redis3m {
-    class exception: public std::exception
+    class exception: public std::runtime_error
     {
     public:
-        exception(const std::string& what):
-        _what(what){}
-        virtual ~exception() throw() {}
-        
-        inline virtual const char* what()
-        {
-            return _what.c_str();
-        }
-    private:
-        std::string _what;
+        explicit exception(const std::string& what) : std::runtime_error(what) {}
+        explicit exception(const char *what) : std::runtime_error(what) {}
+        virtual ~exception() = default;
     };
 }
 
 #define REDIS3M_EXCEPTION(name) class name: public redis3m::exception {\
-public: name(const std::string& what=""): exception(what){}};
+    public: name(const std::string& what="") : exception(std::move(std::string(#name) + ": " + what)) {}\
+    public: name(const char *what) : exception(std::move(std::string(#name) + ": " + what)) {}\
+};
 
 #define REDIS3M_EXCEPTION_2(name, super) class name: public super {\
-    public: name(const std::string& what=""): super(what){}};
+    public: name(const std::string& what="") : super(std::move(std::string(#name) + ": " + what)) {}\
+    public: name(const char *what) : super(std::move(std::string(#name) + ": " + what)) {}\
+};

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -12,7 +12,8 @@ connection::connection(const std::string& host, const unsigned port)
     if (c->err != REDIS_OK)
     {
         redisFree(c);
-        throw unable_to_connect();
+        std::string err = "unable to connect to " + host + ":" + std::to_string(port);
+        throw unable_to_connect(err);
     }
 }
 
@@ -36,7 +37,7 @@ void connection::append(const std::vector<std::string> &commands)
     int ret = redisAppendCommandArgv(c, static_cast<int>(commands.size()), argv.data(), argvlen.data());
     if (ret != REDIS_OK)
     {
-        throw transport_failure();
+        throw transport_failure("connection::append");
     }
 }
 
@@ -46,7 +47,7 @@ reply connection::get_reply()
     int error = redisGetReply(c, reinterpret_cast<void**>(&r));
     if (error != REDIS_OK)
     {
-        throw transport_failure();
+        throw transport_failure("connection::get_reply");
     }
     reply ret(r);
     freeReplyObject(r);
@@ -54,7 +55,7 @@ reply connection::get_reply()
     if (ret.type() == reply::type_t::ERROR &&
 		(ret.str().find("READONLY") == 0) )
     {
-        throw slave_read_only();
+        throw slave_read_only("connection::get_reply");
     }
     return ret;
 }


### PR DESCRIPTION
- base exception class is derived now from std::runtime_error
to reuse already present 'what()' functionality and opening
possibility to catch std::exception and get actual message
- following std notation overloading constructor for const char*
- macros updated correspondingly