### PR TITLE
adding sentinel timeout parameters

### DIFF
--- a/examples/ha_pool.cpp
+++ b/examples/ha_pool.cpp
@@ -5,7 +5,7 @@ using namespace redis3m;
 
 int main(int argc, char **argv)
 {
-    connection_pool::ptr_t pool = connection_pool::create("<yoursentinel>", "test");
+    connection_pool::ptr_t pool = connection_pool::create("<yoursentinel>", "test", 500000); //500ms timeout
     
     connection::ptr_t c = pool->get(connection::MASTER);
     c->run(command("SET") << "foo" << "bar");

--- a/examples/ha_pool.cpp
+++ b/examples/ha_pool.cpp
@@ -5,7 +5,7 @@ using namespace redis3m;
 
 int main(int argc, char **argv)
 {
-    connection_pool::ptr_t pool = connection_pool::create("<yoursentinel>", "test", 500000); //500ms timeout
+    connection_pool::ptr_t pool = connection_pool::createTimeout("sentinel1,sentinel2,sentinel3", "test", 26379, 1, 500000); //1 sec + 500000 usec [1.5 sec] timeout
     
     connection::ptr_t c = pool->get(connection::MASTER);
     c->run(command("SET") << "foo" << "bar");

--- a/include/redis3m/connection.h
+++ b/include/redis3m/connection.h
@@ -9,6 +9,7 @@
 #include <redis3m/reply.h>
 #include <vector>
 #include <memory>
+#include <sys/time.h>
 
 struct redisContext;
 
@@ -25,6 +26,20 @@ class connection: utils::noncopyable
 {
 public:
     typedef std::shared_ptr<connection> ptr_t;
+
+    /**
+     * @brief Create and open a new connection with Timeout
+     * @param host hostname or ip of redis server, default localhost
+     * @param port port of redis server, default: 6379
+     * @param timeval timeout interval struct, default: 1 second
+     * @return
+     */
+    inline static ptr_t createTimeout(const std::string& host="localhost",
+                               const unsigned int port=6379,
+                               const struct timeval timeout=defaultTimeout())
+    {
+        return ptr_t(new connection(host, port, timeout));
+    }
 
     /**
      * @brief Create and open a new connection
@@ -99,10 +114,18 @@ public:
 
 private:
     friend class connection_pool;
+    connection(const std::string& host, const unsigned port, const struct timeval timeout);
     connection(const std::string& host, const unsigned int port);
     connection(const std::string& path);
 
     role_t _role;
     redisContext *c;
+
+    static timeval defaultTimeout(){
+    	struct timeval to;
+    	to.tv_sec = 1;
+    	to.tv_usec = 0;
+    	return to;
+    }
 };
 }

--- a/include/redis3m/connection_pool.h
+++ b/include/redis3m/connection_pool.h
@@ -35,15 +35,17 @@ namespace redis3m {
          * if an host has multiple IPs, connection_pool tries all of them
          * @param master_name Master to lookup
          * @param sentinel_port Sentinel port, default 26379
-         * @param to_usec Timeout microseconds, default 1000000
+         * @param to_sec Timeout seconds, default 1
+         * @param to_usec Timeout microseconds, default 0
          * @return
          */
         static inline ptr_t createTimeout(const std::string& sentinel_host,
                                    const std::string& master_name,
                                    unsigned int sentinel_port=26379,
-                                   long int to_usec=1000000)
+                                   time_t to_sec=1,
+                                   long int to_usec=0)
         {
-            return ptr_t(new connection_pool(sentinel_host, master_name, sentinel_port, to_usec));
+            return ptr_t(new connection_pool(sentinel_host, master_name, sentinel_port, to_sec, to_usec));
         }
 
         /**
@@ -125,6 +127,7 @@ namespace redis3m {
         connection_pool(const std::string& sentinel_host,
 					   const std::string& master_name,
 					   unsigned int sentinel_port,
+					   time_t to_sec,
 					   long int to_usec);
         connection_pool(const std::string& sentinel_host,
                         const std::string& master_name,
@@ -140,6 +143,7 @@ namespace redis3m {
 
         std::vector<std::string> sentinel_hosts;
         unsigned int sentinel_port;
+        time_t to_sec;
         long int to_usec;
         std::string master_name;
         std::string password;

--- a/include/redis3m/connection_pool.h
+++ b/include/redis3m/connection_pool.h
@@ -30,6 +30,23 @@ namespace redis3m {
         typedef std::shared_ptr<connection_pool> ptr_t;
 
         /**
+         * @brief Create a new connection_pool with Timeout
+         * @param sentinel_host Can be a single host or a list separate by commas,
+         * if an host has multiple IPs, connection_pool tries all of them
+         * @param master_name Master to lookup
+         * @param sentinel_port Sentinel port, default 26379
+         * @param to_usec Timeout microseconds, default 1000000
+         * @return
+         */
+        static inline ptr_t createTimeout(const std::string& sentinel_host,
+                                   const std::string& master_name,
+                                   unsigned int sentinel_port=26379,
+                                   long int to_usec=1000000)
+        {
+            return ptr_t(new connection_pool(sentinel_host, master_name, sentinel_port, to_usec));
+        }
+
+        /**
          * @brief Create a new connection_pool
          * @param sentinel_host Can be a single host or a list separate by commas,
          * if an host has multiple IPs, connection_pool tries all of them
@@ -106,6 +123,10 @@ namespace redis3m {
 
     private:
         connection_pool(const std::string& sentinel_host,
+					   const std::string& master_name,
+					   unsigned int sentinel_port,
+					   long int to_usec);
+        connection_pool(const std::string& sentinel_host,
                         const std::string& master_name,
                         unsigned int sentinel_port);
         connection::ptr_t create_slave_connection();
@@ -119,6 +140,7 @@ namespace redis3m {
 
         std::vector<std::string> sentinel_hosts;
         unsigned int sentinel_port;
+        long int to_usec;
         std::string master_name;
         std::string password;
         unsigned int _database;

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -6,6 +6,16 @@
 
 using namespace redis3m;
 
+connection::connection(const std::string& host, const unsigned port, const struct timeval timeout)
+{
+    c = redisConnectWithTimeout(host.c_str(), port, timeout);
+    if (c->err != REDIS_OK)
+    {
+        redisFree(c);
+        throw unable_to_connect();
+    }
+}
+
 connection::connection(const std::string& host, const unsigned port)
 {
     c = redisConnect(host.c_str(), port);

--- a/src/connection_pool.cpp
+++ b/src/connection_pool.cpp
@@ -171,11 +171,16 @@ connection::ptr_t connection_pool::sentinel_connection()
 #endif
             try
             {
-                //return connection::create(real_sentinel, sentinel_port);
-            	struct timeval to;
-				to.tv_sec = 1;
-				to.tv_usec = 0;
-            	return connection::createTimeout(real_sentinel, sentinel_port, to);
+				if(to_usec > 0){ //check for valid timeout value
+					struct timeval to;
+					to.tv_sec = 0;
+					to.tv_usec = to_usec;
+					return connection::createTimeout(real_sentinel, sentinel_port, to);
+            	}
+				else
+				{
+					return connection::create(real_sentinel, sentinel_port); //normal connection
+				}
 
             } catch (const unable_to_connect& )
             {

--- a/src/connection_pool.cpp
+++ b/src/connection_pool.cpp
@@ -41,12 +41,12 @@ _database(0)
 #ifndef NO_BOOST
     boost::algorithm::split(sentinel_hosts, sentinel_host, boost::is_any_of(","), boost::token_compress_on);
 #else //http://stackoverflow.com/questions/5167625/splitting-a-c-stdstring-using-tokens-e-g
-	std::string s;
-	std::istringstream f(sentinel_host.c_str());
-	while (std::getline(f, s, ',')) {
-		std::cout << s << std::endl;
-		sentinel_hosts.push_back(s);
-	}
+    std::string s;
+    std::istringstream f(sentinel_host.c_str());
+    while (std::getline(f, s, ',')) {
+        std::cout << s << std::endl;
+        sentinel_hosts.push_back(s);
+    }
 #endif
 }
 
@@ -63,12 +63,12 @@ _database(0)
 #ifndef NO_BOOST
     boost::algorithm::split(sentinel_hosts, sentinel_host, boost::is_any_of(","), boost::token_compress_on);
 #else //http://stackoverflow.com/questions/5167625/splitting-a-c-stdstring-using-tokens-e-g
-	std::string s;
-	std::istringstream f(sentinel_host.c_str());
-	while (std::getline(f, s, ',')) {
-		std::cout << s << std::endl;
-		sentinel_hosts.push_back(s);
-	}
+    std::string s;
+    std::istringstream f(sentinel_host.c_str());
+    while (std::getline(f, s, ',')) {
+        std::cout << s << std::endl;
+        sentinel_hosts.push_back(s);
+    }
 #endif
 }
 
@@ -174,17 +174,16 @@ connection::ptr_t connection_pool::sentinel_connection()
 #endif
             try
             {
-				if(to_usec >= 0 && to_sec >= 0){ //check for valid timeout values
-					struct timeval to;
-					to.tv_sec = to_sec;
-					to.tv_usec = to_usec;
-					return connection::createTimeout(real_sentinel, sentinel_port, to);
-				}
-				else
-				{
-					return connection::create(real_sentinel, sentinel_port); //normal connection
-				}
-
+                if(to_usec >= 0 && to_sec >= 0){ //check for valid timeout values
+                    struct timeval to;
+                    to.tv_sec = to_sec;
+                    to.tv_usec = to_usec;
+                    return connection::createTimeout(real_sentinel, sentinel_port, to);
+                }
+                else
+                {
+                    return connection::create(real_sentinel, sentinel_port); //normal connection
+                }
             } catch (const unable_to_connect& )
             {
 #ifndef NO_BOOST
@@ -200,24 +199,24 @@ connection::ptr_t connection_pool::sentinel_connection()
 
 connection::role_t connection_pool::get_role(connection::ptr_t conn)
 {
-	static const 
+    static const 
 #ifndef NO_BOOST
     boost::regex 
 #else
-	std::regex 
+    std::regex 
 #endif
-	role_searcher("\r\nrole:([a-z]+)\r\n");
+    role_searcher("\r\nrole:([a-z]+)\r\n");
 
     reply r = conn->run(command("ROLE"));
     std::string role_s;
 
     if (r.type() == reply::type_t::ERROR
 #ifndef NO_BOOST
-		&& boost::algorithm::find_first(r.str(),"unknown"))
+        && boost::algorithm::find_first(r.str(),"unknown"))
 #else
-		&& (r.str().find("unknown") != std::string::npos) )
+        && (r.str().find("unknown") != std::string::npos) )
 #endif
-		
+        
     {
         logging::debug("Old redis, doesn't support ROLE command");
         reply r = conn->run(command("INFO") << "replication");
@@ -225,8 +224,8 @@ connection::role_t connection_pool::get_role(connection::ptr_t conn)
         boost::smatch results;
         if (boost::regex_search(r.str(), results, role_searcher))
 #else
-		std::smatch results;
-		if (std::regex_search(r.str(), results, role_searcher))
+        std::smatch results;
+        if (std::regex_search(r.str(), results, role_searcher))
 #endif
         {
             role_s = results[1];
@@ -398,3 +397,4 @@ void connection_pool::run_with_connection(std::function<void(connection::ptr_t)>
     }
     throw too_much_retries();
 }
+

--- a/src/connection_pool.cpp
+++ b/src/connection_pool.cpp
@@ -29,9 +29,11 @@ using namespace redis3m;
 connection_pool::connection_pool(const std::string& sentinel_host,
                                  const std::string& master_name,
                                  unsigned int sentinel_port,
+                                 time_t to_sec,
                                  long int to_usec):
 master_name(master_name),
 sentinel_port(sentinel_port),
+to_sec(to_sec),
 to_usec(to_usec),
 password(""),
 _database(0)
@@ -53,6 +55,7 @@ connection_pool::connection_pool(const std::string& sentinel_host,
                                  unsigned int sentinel_port):
 master_name(master_name),
 sentinel_port(sentinel_port),
+to_sec(-1),
 to_usec(-1),
 password(""),
 _database(0)
@@ -171,12 +174,12 @@ connection::ptr_t connection_pool::sentinel_connection()
 #endif
             try
             {
-				if(to_usec > 0){ //check for valid timeout value
+				if(to_usec >= 0 && to_sec >= 0){ //check for valid timeout values
 					struct timeval to;
-					to.tv_sec = 0;
+					to.tv_sec = to_sec;
 					to.tv_usec = to_usec;
 					return connection::createTimeout(real_sentinel, sentinel_port, to);
-            	}
+				}
 				else
 				{
 					return connection::create(real_sentinel, sentinel_port); //normal connection


### PR DESCRIPTION
allows for lower connectivity timeout when connecting to sentinels in redis HA cluster mode.