### PR TITLE
Fixes compilation issues with FreeBSD.

### DIFF
--- a/src/utils/resolv.cpp
+++ b/src/utils/resolv.cpp
@@ -13,6 +13,10 @@
 #endif
 #include <string.h>
 
+#if __FreeBSD__
+#include <netinet/in.h>
+#endif
+
 using namespace redis3m;
 
 std::vector<std::string> resolv::get_addresses(const std::string &hostname)


### PR DESCRIPTION
This commit fixes a compilation error on FreeBSD. The discrepancy lies
in how sockaddr_in is defined. The relevant information can be found at

https://www.freebsd.org/doc/en/books/developers-handbook/sockets-essential-functions.html